### PR TITLE
fix typo in Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: mercury runserver & gunicorn mercury.server.wsgi --bind 0.0.0.0:$PORT --workers 2 --threads 2 
+web: mercury runworker & gunicorn mercury.server.wsgi --bind 0.0.0.0:$PORT --workers 2 --threads 2 


### PR DESCRIPTION
There was a typo in Procfile, so the worker never started. That's why there was still loading state.